### PR TITLE
Fix the scheduling of wr/rd loops according to mirage-solo5.0.9.1

### DIFF
--- a/mirage/config.ml
+++ b/mirage/config.ml
@@ -18,12 +18,8 @@ let bob =
   foreign "Unikernel.Make"
     ~packages:
       [
-        package "bob"
-          ~pin:
-            "git+https://github.com/dinosaure/bob.git#3c85fff2aba1bbf0d0e7f05427d7e41f9b7a7cc3";
-        package "spoke" ~sublibs:[ "core" ]
-          ~pin:
-            "git+https://github.com/dinosaure/spoke.git#61f4e785d22d6002fd396862f75f515355197002";
+        package "bob" ~pin:"https://github.com/dinosaure/bob.git";
+        package "spoke" ~sublibs:[ "core" ];
         package "psq";
       ]
     ~keys:[ Key.v port; Key.v secure_port ]


### PR DESCRIPTION
Currently, `Lwt.pause` does not align our computations to the next event but if we have computations with `Lwt.pause` and we don't have sleepers (and it's the case), we try to resolve them as soon as we can. That's mostly say that `Lwt.pause () >>= go` can be a no-op if you don't have a sleeper somewhere: you finally have an infinite loop.

Such behavior came with the last release of `mirage-solo5`. This patch wants to reschedule correctly operations:
1) between the `rd` and the `wr` loop for the handshake: a new connection unlocks the reader and writer. The reader is a scan of all peers where a fiber exists (and wants to `read`). If a fiber `read` something, we notify the writer that something should appears. The writer then try to unfold everything and re-ask the reader to re-scan everything.
2) For the secure room, it's a basic queue. So a waiter exists until the queue is not empty. Of course, we notify the condition when we fill the queue.

I'm not super convinced by such design but it seems to work, so let's merge.