### PR TITLE
Upgrade bob_dns with the new version of happy-eyeballs

### DIFF
--- a/bob.opam
+++ b/bob.opam
@@ -13,28 +13,28 @@ build: [ "dune" "build" "-p" name "-j" jobs ]
 run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
 
 depends: [
-  "ocaml"       {>= "4.13.0"}
-  "dune"        {>= "2.8.0"}
-  "fmt"         {>= "0.9.0"}
-  "hxd"         {>= "0.3.2"}
-  "logs"        {>= "0.7.0"}
-  "bheap"       {>= "2.0.0"}
-  "base64"      {>= "3.5.0"}
-  "decompress"  {>= "1.5.1"}
-  "digestif"    {>= "1.1.3"}
+  "ocaml"          {>= "4.13.0"}
+  "dune"           {>= "2.8.0"}
+  "fmt"            {>= "0.9.0"}
+  "hxd"            {>= "0.3.2"}
+  "logs"           {>= "0.7.0"}
+  "bheap"          {>= "2.0.0"}
+  "base64"         {>= "3.5.0"}
+  "decompress"     {>= "1.5.1"}
+  "digestif"       {>= "1.1.3"}
   "bigstringaf"
   "cmdliner"
   "ipaddr"
   "mirage-crypto"
   "psq"
   "tls"
-  "carton"      {>= "0.5.0"}
+  "carton"         {>= "0.5.0"}
   "progress"
-  "dns-client"  {>= "6.4.0"}
-  "happy-eyeballs"
+  "dns-client"     {>= "6.4.0"}
+  "happy-eyeballs" {>= "0.4.0" & < "0.5.0"}
   "ca-certs"
-  "ke"          {>= "0.6"}
-  "alcotest"    {with-test}
+  "ke"             {>= "0.6"}
+  "alcotest"       {with-test}
   "spoke"
 ]
 

--- a/com.opam
+++ b/com.opam
@@ -38,7 +38,7 @@ depends: [
   "carton"         { ?monorepo & >= "0.5.0" }
   "progress"       { ?monorepo }
   "dns-client"     { ?monorepo }
-  "happy-eyeballs" { ?monorepo }
+  "happy-eyeballs" { ?monorepo & >= "0.4.0" & < "0.5.0" }
   "ca-certs"       { ?monorepo }
   "ke"             { ?monorepo & >= "0.6" }
   "alcotest"       { with-test }


### PR DESCRIPTION
Related to mirage/ocaml-dns#329 and spotted by @fdagnat. I restricted the version of `happy-eyeballs`. Fix #29.