### PR TITLE
Add the SOCKSv{4,5} support to be able to pass through the Tor network

### DIFF
--- a/bin/args.ml
+++ b/bin/args.ml
@@ -339,3 +339,12 @@ let destination =
     Arg.conv (parser, pp)
   in
   Arg.(value & opt (some name) None & info [ "o"; "output" ] ~doc ~docv:"<dst>")
+
+let through =
+  let doc =
+    "The user can communicate with the relay $(b,through) a SOCKSv{4a,5} \
+     server (usually, a Tor server). The format of the argument is: \
+     [socks{4,4a,5}://(username:password@)?hostname(:port)?]"
+  in
+  let server = Arg.conv Bob_socks.(parser, pp) in
+  Arg.(value & opt (some server) None & info [ "through" ] ~doc ~docv:"<socks>")

--- a/bin/bob.ml
+++ b/bin/bob.ml
@@ -1,13 +1,15 @@
 let () = Printexc.record_backtrace true
 
-let run quiet g temp dns compression addr secure_port yes dst = function
+let run quiet g temp dns compression through addr secure_port yes dst = function
   | Some path when Sys.file_exists path ->
       let password = Args.setup_password quiet g None in
-      Send.run temp dns None compression addr secure_port false password
+      Send.run temp dns through None compression addr secure_port false password
         (Bob_fpath.v path)
   | Some password ->
-      Recv.run quiet g temp dns addr secure_port false (Some password) yes dst
-  | None -> Recv.run quiet g temp dns addr secure_port false None yes dst
+      Recv.run quiet g temp dns through addr secure_port false (Some password)
+        yes dst
+  | None ->
+      Recv.run quiet g temp dns through addr secure_port false None yes dst
 
 open Cmdliner
 open Args
@@ -20,8 +22,8 @@ let term =
   Term.(
     ret
       (const run $ term_setup_logs $ term_setup_random $ term_setup_temp
-     $ term_setup_dns $ compression $ relay $ secure_port $ yes $ destination
-     $ path_or_password))
+     $ term_setup_dns $ compression $ through $ relay $ secure_port $ yes
+     $ destination $ path_or_password))
 
 let cmd =
   let doc = "An universal & secure peer-to-peer file-transfer program." in

--- a/bin/dune
+++ b/bin/dune
@@ -52,7 +52,8 @@
   bob.pack
   bob.tls
   bob.dns
-  bob.happy-eyeballs))
+  bob.happy-eyeballs
+  bob.socks))
 
 ; (rule
 ;  (target cat.com)

--- a/bin/recv.ml
+++ b/bin/recv.ml
@@ -6,6 +6,12 @@ let choose = function
   | false ->
       let open Fiber in
       fun identity ->
+        let human_readable_identity =
+          Password.identity_of_seed
+            (Password.compile Dict.En.words)
+            ~seed:identity
+          |> Result.get_ok
+        in
         let rec asking () =
           Fiber.getline Unix.stdin >>| Stdlib.Option.map String.lowercase_ascii
           >>= function
@@ -15,7 +21,7 @@ let choose = function
               Fmt.pr "Invalid response, accept from %s [Y/n]: %!" identity;
               asking ()
         in
-        Fmt.pr "Accept from %s [Y/n]: %!" identity;
+        Fmt.pr "Accept from %s [Y/n]: %!" human_readable_identity;
         asking ()
 
 let ask_password () =

--- a/bin/recv.ml
+++ b/bin/recv.ml
@@ -36,12 +36,12 @@ let ask_password () =
   Fmt.pr "Your password: %!";
   asking ()
 
-let source_with_reporter quiet ~config ~identity ~ciphers ~shared_keys sockaddr
-    : (string Stream.source, _) result Fiber.t =
+let source_with_reporter quiet ~config ~identity ~ciphers ~shared_keys
+    ~happy_eyeballs ?through addr : (string Stream.source, _) result Fiber.t =
   with_reporter ~config quiet incoming_data @@ fun (reporter, finalise) ->
   Transfer.receive
     ~reporter:(Fiber.return <.> reporter)
-    ~finalise ~identity ~ciphers ~shared_keys sockaddr
+    ~finalise ~identity ~ciphers ~shared_keys ~happy_eyeballs ?through addr
 
 let make_window bits = De.make_window ~bits
 
@@ -254,14 +254,15 @@ let run_client quiet g (_, he) through addr secure_port reproduce password yes
   (match through with
   | Some server -> Bob_socks.connect ~happy_eyeballs:he ~server addr
   | None -> Bob_happy_eyeballs.connect he addr)
-  >>? fun (sockaddr, socket) ->
+  >>? fun (_sockaddr, socket) ->
   Logs.debug (fun m -> m "The client is connected to the relay.");
   let choose = choose yes in
   Bob_clear.client socket ~reproduce ~choose ~g password
   >>? fun (identity, ciphers, shared_keys) ->
   let config = Progress.Config.v ~ppf:Fmt.stdout () in
-  let sockaddr = Transfer.sockaddr_with_secure_port sockaddr secure_port in
-  source_with_reporter quiet ~config ~identity ~ciphers ~shared_keys sockaddr
+  let addr = Transfer.addr_with_secure_port addr secure_port in
+  source_with_reporter quiet ~config ~identity ~ciphers ~shared_keys
+    ~happy_eyeballs:he ?through addr
   >>| Transfer.open_error
   >>? fun source -> extract_with_reporter quiet ~config ~g source destination
 

--- a/bin/recv.ml
+++ b/bin/recv.ml
@@ -244,14 +244,17 @@ let extract_with_reporter quiet ~config ?g (from : string Stream.source)
                 name Bob_fpath.pp destination);
           unpack_with_reporter quiet ~config ~total pack destination hash)
 
-let run_client quiet g (_, he) addr secure_port reproduce password yes
+let run_client quiet g (_, he) through addr secure_port reproduce password yes
     destination =
   let open Fiber in
   (match password with
   | Some password -> Fiber.return password
   | None -> ask_password ())
   >>= fun password ->
-  Bob_happy_eyeballs.connect he addr >>? fun (sockaddr, socket) ->
+  (match through with
+  | Some server -> Bob_socks.connect ~happy_eyeballs:he ~server addr
+  | None -> Bob_happy_eyeballs.connect he addr)
+  >>? fun (sockaddr, socket) ->
   Logs.debug (fun m -> m "The client is connected to the relay.");
   let choose = choose yes in
   Bob_clear.client socket ~reproduce ~choose ~g password
@@ -270,10 +273,12 @@ let pp_error ppf = function
   | `No_root -> Fmt.pf ppf "The given PACK file has no root"
   | `Msg err -> Fmt.pf ppf "%s" err
 
-let run quiet g () dns_and_he addr secure_port reproduce password yes dst =
+let run quiet g () dns_and_he through addr secure_port reproduce password yes
+    dst =
   match
     Fiber.run
-      (run_client quiet g dns_and_he addr secure_port reproduce password yes dst)
+      (run_client quiet g dns_and_he through addr secure_port reproduce password
+         yes dst)
   with
   | Ok () -> `Ok 0
   | Error err ->
@@ -291,8 +296,8 @@ let term =
   Term.(
     ret
       (const run $ term_setup_logs $ term_setup_random $ term_setup_temp
-     $ term_setup_dns $ relay $ secure_port $ reproduce $ password $ yes
-     $ destination))
+     $ term_setup_dns $ through $ relay $ secure_port $ reproduce $ password
+     $ yes $ destination))
 
 let cmd =
   let doc = "Receive a file from a peer who share the given password." in

--- a/bin/send.ml
+++ b/bin/send.ml
@@ -116,7 +116,17 @@ let run_server quiet g (_, he) mime_type compression addr secure_port reproduce
   let open Fiber in
   Bob_happy_eyeballs.connect he addr >>? fun (sockaddr, socket) ->
   generate_pack_file quiet ~g ~config compression path >>= fun pack ->
-  Bob_clear.server socket ~reproduce ~g secret
+  let identity =
+    if quiet then Fun.const (Fiber.return ())
+    else fun seed ->
+      let identity =
+        Password.identity_of_seed (Password.compile Dict.En.words) ~seed
+        |> Result.get_ok
+      in
+      Fmt.pr "%s\rIdentity: %s\n%!" Terminal.Ansi.erase_line identity;
+      Fiber.return ()
+  in
+  Bob_clear.server socket ~reproduce ~g ~identity secret
   >>? fun (identity, ciphers, shared_keys) ->
   let sockaddr = Transfer.sockaddr_with_secure_port sockaddr secure_port in
   transfer_with_reporter quiet ~config ~identity ~ciphers:(flip ciphers)

--- a/bin/send.ml
+++ b/bin/send.ml
@@ -103,8 +103,8 @@ let better_to_compress_for mime_type =
   | "video" :: _ | "audio" :: _ | "image" :: _ -> false
   | _ -> true
 
-let run_server quiet g (_, he) mime_type compression addr secure_port reproduce
-    password path =
+let run_server quiet g (_, he) through mime_type compression addr secure_port
+    reproduce password path =
   let compression =
     match (mime_type, compression) with
     | None, None -> true
@@ -114,7 +114,10 @@ let run_server quiet g (_, he) mime_type compression addr secure_port reproduce
   let config = Progress.Config.v ~ppf:Fmt.stdout () in
   let secret, _ = Spoke.generate ~g ~password ~algorithm:Spoke.Pbkdf2 16 in
   let open Fiber in
-  Bob_happy_eyeballs.connect he addr >>? fun (sockaddr, socket) ->
+  (match through with
+  | Some server -> Bob_socks.connect ~happy_eyeballs:he ~server addr
+  | None -> Bob_happy_eyeballs.connect he addr)
+  >>? fun (sockaddr, socket) ->
   generate_pack_file quiet ~g ~config compression path >>= fun pack ->
   let identity =
     if quiet then Fun.const (Fiber.return ())
@@ -138,12 +141,12 @@ let pp_error ppf = function
   | #Bob_clear.error as err -> Bob_clear.pp_error ppf err
   | `Msg err -> Fmt.pf ppf "%s" err
 
-let run () dns_and_he mime_type compression addr secure_port reproduce
+let run () dns_and_he through mime_type compression addr secure_port reproduce
     (quiet, g, password) path =
   match
     Fiber.run
-      (run_server quiet g dns_and_he mime_type compression addr secure_port
-         reproduce password path)
+      (run_server quiet g dns_and_he through mime_type compression addr
+         secure_port reproduce password path)
   with
   | Ok () -> `Ok 0
   | Error err ->
@@ -200,7 +203,7 @@ let cmd =
     (Cmd.info "send" ~doc ~man)
     Term.(
       ret
-        (const run $ term_setup_temp $ term_setup_dns $ mime_type $ compression
-       $ relay $ secure_port $ reproduce
+        (const run $ term_setup_temp $ term_setup_dns $ through $ mime_type
+       $ compression $ relay $ secure_port $ reproduce
         $ term_setup_password password
         $ path))

--- a/bin/send.ml
+++ b/bin/send.ml
@@ -127,7 +127,7 @@ let run_server quiet g (_, he) through mime_type compression addr secure_port
         Password.identity_of_seed (Password.compile Dict.En.words) ~seed
         |> Result.get_ok
       in
-      Fmt.pr "%s\rIdentity: %s\n%!" Terminal.Ansi.erase_line identity;
+      Progress.interject_with (fun () -> Fmt.pr "Identity: %s\n%!" identity);
       Fiber.return ()
   in
   Bob_clear.server socket ~reproduce ~g ~identity secret

--- a/bin/send.ml
+++ b/bin/send.ml
@@ -51,10 +51,11 @@ let emit_one_with_reporter quiet ?level ~config path =
   | Ok stream -> Fiber.return (Stream stream)
 
 let transfer_with_reporter quiet ~config ~identity ~ciphers ~shared_keys
-    sockaddr = function
+    ~happy_eyeballs ?through addr = function
   | Stream stream ->
       let stream = Stream.(Stream.via Flow.bstr_to_string stream) in
-      Transfer.transfer ~identity ~ciphers ~shared_keys sockaddr stream
+      Transfer.transfer ~identity ~ciphers ~shared_keys ~happy_eyeballs ?through
+        addr stream
   | File path ->
       let total = (Unix.stat (Bob_fpath.to_string path)).Unix.st_size in
       with_reporter ~config quiet (make_tranfer_bar ~total)
@@ -75,7 +76,7 @@ let transfer_with_reporter quiet ~config ~identity ~ciphers ~shared_keys
       let stream = Stream.via Flow.bstr_to_string stream in
       Transfer.transfer
         ~reporter:(Fiber.return <.> reporter)
-        ~identity ~ciphers ~shared_keys sockaddr stream
+        ~identity ~ciphers ~shared_keys ~happy_eyeballs ?through addr stream
       >>| fun res ->
       finalise ();
       res
@@ -117,7 +118,7 @@ let run_server quiet g (_, he) through mime_type compression addr secure_port
   (match through with
   | Some server -> Bob_socks.connect ~happy_eyeballs:he ~server addr
   | None -> Bob_happy_eyeballs.connect he addr)
-  >>? fun (sockaddr, socket) ->
+  >>? fun (_sockaddr, socket) ->
   generate_pack_file quiet ~g ~config compression path >>= fun pack ->
   let identity =
     if quiet then Fun.const (Fiber.return ())
@@ -131,9 +132,9 @@ let run_server quiet g (_, he) through mime_type compression addr secure_port
   in
   Bob_clear.server socket ~reproduce ~g ~identity secret
   >>? fun (identity, ciphers, shared_keys) ->
-  let sockaddr = Transfer.sockaddr_with_secure_port sockaddr secure_port in
+  let addr = Transfer.addr_with_secure_port addr secure_port in
   transfer_with_reporter quiet ~config ~identity ~ciphers:(flip ciphers)
-    ~shared_keys:(flip shared_keys) sockaddr pack
+    ~shared_keys:(flip shared_keys) ~happy_eyeballs:he ?through addr pack
   >>| Transfer.open_error
 
 let pp_error ppf = function

--- a/bin/transfer.ml
+++ b/bin/transfer.ml
@@ -4,10 +4,10 @@ let src = Logs.Src.create "bob.transfer"
 
 module Log = (val Logs.src_log src : Logs.LOG)
 
-let sockaddr_with_secure_port sockaddr secure_port =
-  match sockaddr with
-  | Unix.ADDR_INET (inet_addr, _) -> Unix.ADDR_INET (inet_addr, secure_port)
-  | Unix.ADDR_UNIX _ -> invalid_arg "Invalid sockaddr"
+let addr_with_secure_port addr secure_port =
+  match addr with
+  | `Inet (inet_addr, _) -> `Inet (inet_addr, secure_port)
+  | `Domain (host, _) -> `Domain (host, secure_port)
 
 let max_packet =
   2 + Bob_unix.Crypto.max_packet + 16 (* header + data + tag_size *)
@@ -42,13 +42,16 @@ end)
 
 type error =
   [ Bob_unix.error
-  | `Connect of Unix.error
+  | `Connect of [ `Closed | `Msg of string | `Unix of Unix.error ]
   | `Blocking_connect of Connect.error
   | `Crypto of [ Crypto.write_error | Crypto.error ] ]
 
 let pp_error ppf = function
   | `Blocking_connect err -> Connect.pp_error ppf err
-  | `Connect errno -> Fmt.pf ppf "connect(): %s" (Unix.error_message errno)
+  | `Connect `Closed -> Fmt.pf ppf "connect(): Connection reset by peer"
+  | `Connect (`Msg msg) -> Fmt.pf ppf "connect(): %s" msg
+  | `Connect (`Unix errno) ->
+      Fmt.pf ppf "connect(): %s" (Unix.error_message errno)
   | `Crypto (#Crypto.write_error as err) -> Crypto.pp_write_error ppf err
   | `Crypto (#Crypto.error as err) -> Crypto.pp_error ppf err
   | #Bob_unix.error as err -> Bob_unix.pp_error ppf err
@@ -98,17 +101,13 @@ let crypto_of_flow ~reporter ~ciphers ~shared_keys socket =
   Stream.Sink { init; push; full; stop }
 
 let transfer ?chunk:_ ?(reporter = Fiber.ignore) ~identity ~ciphers ~shared_keys
-    sockaddr stream =
-  let { Unix.p_proto; _ } =
-    try Unix.getprotobyname "tcp"
-    with _ ->
-      (* fail on Windows *) { p_name = "tcp"; p_aliases = [||]; p_proto = 0 }
-  in
-  let domain = Unix.domain_of_sockaddr sockaddr in
-  let socket = Unix.socket ~cloexec:true domain Unix.SOCK_STREAM p_proto in
+    ~happy_eyeballs ?through addr stream =
   let open Fiber in
-  Fiber.connect socket sockaddr >>| reword_error (fun err -> `Connect err)
-  >>? fun () ->
+  (match through with
+  | Some server -> Bob_socks.connect ~happy_eyeballs ~server addr
+  | None -> Bob_happy_eyeballs.connect happy_eyeballs addr)
+  >>| reword_error (fun err -> `Connect err)
+  >>? fun (_sockaddr, socket) ->
   Bob_unix.init_peer socket ~identity >>= function
   | Error (#Bob_unix.error as err) ->
       Fiber.close socket >>= fun () -> Fiber.return (Error (err :> error))
@@ -146,17 +145,13 @@ let crypto_of_flow ~reporter ~finalise ~ciphers ~shared_keys socket =
   Stream.Source { init; pull; stop }
 
 let receive ?(reporter = Fiber.ignore) ?(finalise = ignore) ~identity ~ciphers
-    ~shared_keys sockaddr =
-  let { Unix.p_proto; _ } =
-    try Unix.getprotobyname "tcp"
-    with _ ->
-      (* fail on Windows *) { p_name = "tcp"; p_aliases = [||]; p_proto = 0 }
-  in
-  let domain = Unix.domain_of_sockaddr sockaddr in
-  let socket = Unix.socket ~cloexec:true domain Unix.SOCK_STREAM p_proto in
+    ~shared_keys ~happy_eyeballs ?through addr =
   let open Fiber in
-  Fiber.connect socket sockaddr >>| reword_error (fun err -> `Connect err)
-  >>? fun () ->
+  (match through with
+  | Some server -> Bob_socks.connect ~happy_eyeballs ~server addr
+  | None -> Bob_happy_eyeballs.connect happy_eyeballs addr)
+  >>| reword_error (fun err -> `Connect err)
+  >>? fun (_sockaddr, socket) ->
   Bob_unix.init_peer socket ~identity >>= function
   | Error (#Bob_unix.error as err) ->
       Fiber.close socket >>= fun () -> Fiber.return (Error (err :> error))

--- a/bin/transfer.mli
+++ b/bin/transfer.mli
@@ -1,7 +1,7 @@
 type error =
   [ Bob_unix.error
   | `Blocking_connect of Connect.error
-  | `Connect of Unix.error
+  | `Connect of [ `Closed | `Msg of string | `Unix of Unix.error ]
   | `Crypto of
     [ `Closed
     | `Corrupted
@@ -10,7 +10,7 @@ type error =
 
 val pp_error : error Fmt.t
 val open_error : ('a, error) result -> ('a, [> error ]) result
-val sockaddr_with_secure_port : Unix.sockaddr -> int -> Unix.sockaddr
+val addr_with_secure_port : Bob_socks.addr -> int -> Bob_socks.addr
 val max_packet : int
 
 val transfer :
@@ -19,7 +19,9 @@ val transfer :
   identity:string ->
   ciphers:Spoke.cipher * Spoke.cipher ->
   shared_keys:string * string ->
-  Unix.sockaddr ->
+  happy_eyeballs:Bob_happy_eyeballs.t ->
+  ?through:Bob_socks.server ->
+  Bob_socks.addr ->
   string Stream.stream ->
   (unit, error) result Fiber.t
 
@@ -29,5 +31,7 @@ val receive :
   identity:string ->
   ciphers:Spoke.cipher * Spoke.cipher ->
   shared_keys:string * string ->
-  Unix.sockaddr ->
+  happy_eyeballs:Bob_happy_eyeballs.t ->
+  ?through:Bob_socks.server ->
+  Bob_socks.addr ->
   (string Stream.source, error) result Fiber.t

--- a/bob.opam
+++ b/bob.opam
@@ -40,10 +40,11 @@ depends: [
   "alcotest"          {with-test}
   "spoke"             {>= "0.0.3"}
   "bstr"
+  "socks"
 ]
 
 pin-depends: [
-  [ "spoke.dev" "git+https://github.com/dinosaure/spoke.git#eda61bb0c2671f3eaaac9f0f0ffa8423b3e63c98" ]
+  [ "socks.dev" "git+https://github.com/dinosaure/ocaml-socks.git#31399dab6812cb3fbf28b9eea5c5e4a3939abe4b" ]
 ]
 
 available: arch != "x86_32"

--- a/bob.opam
+++ b/bob.opam
@@ -44,7 +44,7 @@ depends: [
 ]
 
 pin-depends: [
-  [ "socks.dev" "git+https://github.com/dinosaure/ocaml-socks.git#31399dab6812cb3fbf28b9eea5c5e4a3939abe4b" ]
+  [ "socks.dev" "git+https://github.com/cfcs/ocaml-socks.git#c46ed399df18307e5240457b9d5d4ff8a6739f06" ]
 ]
 
 available: arch != "x86_32"

--- a/com.opam
+++ b/com.opam
@@ -66,7 +66,7 @@ pin-depends: [
     [ "mirage-crypto-pk.2.0.0" "git+https://github.com/dinosaure/mirage-crypto.git#24e20a0681b221954f7bac9dc76559007aaeb09a" ]
     [ "mirage-crypto-ec.2.0.0" "git+https://github.com/dinosaure/mirage-crypto.git#24e20a0681b221954f7bac9dc76559007aaeb09a" ]
     [ "mirage-crypto-rng.2.0.0" "git+https://github.com/dinosaure/mirage-crypto.git#24e20a0681b221954f7bac9dc76559007aaeb09a" ]
-    [ "socks.dev" "git+https://github.com/dinosaure/ocaml-socks.git#31399dab6812cb3fbf28b9eea5c5e4a3939abe4b" ]
+    [ "socks.dev" "git+https://github.com/cfcs/ocaml-socks.git#c46ed399df18307e5240457b9d5d4ff8a6739f06" ]
 ]
 
 x-mirage-opam-lock-location: "com.opam.locked"

--- a/com.opam
+++ b/com.opam
@@ -57,6 +57,7 @@ depends: [
   "alcotest"               { with-test }
   "spoke"                  { > "0.0.3" }
   "bstr"
+  "socks"
 ]
 
 pin-depends: [
@@ -65,8 +66,7 @@ pin-depends: [
     [ "mirage-crypto-pk.2.0.0" "git+https://github.com/dinosaure/mirage-crypto.git#24e20a0681b221954f7bac9dc76559007aaeb09a" ]
     [ "mirage-crypto-ec.2.0.0" "git+https://github.com/dinosaure/mirage-crypto.git#24e20a0681b221954f7bac9dc76559007aaeb09a" ]
     [ "mirage-crypto-rng.2.0.0" "git+https://github.com/dinosaure/mirage-crypto.git#24e20a0681b221954f7bac9dc76559007aaeb09a" ]
-#   [ "mtime.dev" "git+https://github.com/dinosaure/mtime.git#d5d70f38c40da90e3e173eb60346df55b64a4a0a" ]
-#   [ "gmp.dev" "git+https://github.com/mirage/ocaml-gmp.git#90c7941b3b2649c19f2596538417e5ce1df61b9d" ]
+    [ "socks.dev" "git+https://github.com/dinosaure/ocaml-socks.git#31399dab6812cb3fbf28b9eea5c5e4a3939abe4b" ]
 ]
 
 x-mirage-opam-lock-location: "com.opam.locked"

--- a/lib/bob.mli
+++ b/lib/bob.mli
@@ -10,10 +10,11 @@ module Server : sig
   val receive :
     t ->
     [ `End | `Data of string * int * int ] ->
-    [> `Continue
+    [ `Continue
     | `Read
     | `Close
     | `Done of string * (Spoke.cipher * Spoke.cipher) * Spoke.shared_keys
+    | `Identity of string
     | `Agreement of string
     | `Error of Handshake.error ]
 
@@ -29,10 +30,11 @@ module Client : sig
   val receive :
     t ->
     [ `End | `Data of string * int * int ] ->
-    [> `Continue
+    [ `Continue
     | `Read
     | `Close
     | `Done of string * (Spoke.cipher * Spoke.cipher) * Spoke.shared_keys
+    | `Identity of string
     | `Agreement of string
     | `Error of Handshake.error ]
 

--- a/lib/bob_socks.ml
+++ b/lib/bob_socks.ml
@@ -1,0 +1,206 @@
+open Stdbob
+open Socks
+
+let fully_write fd bs =
+  let open Fiber in
+  let rec go (off, len) =
+    if len > 0 then
+      Fiber.write fd bs ~off ~len >>= function
+      | Ok len' -> go (off + len', len - len')
+      | Error err -> Fiber.return (Error err)
+    else Fiber.return (Ok ())
+  in
+  go (0, Bigarray.Array1.dim bs)
+
+let addr_to_string_and_int = function
+  | `Inet (inet_addr, port) -> (Unix.string_of_inet_addr inet_addr, port)
+  | `Domain (domain_name, port) -> (Domain_name.to_string domain_name, port)
+
+type addr =
+  [ `Inet of Unix.inet_addr * int | `Domain of [ `host ] Domain_name.t * int ]
+
+type identifier = Username of string | Credential of string * string | None
+type server = [ `Socks4a | `Socks5 ] * identifier * addr
+
+let parser str =
+  let default = 1080 in
+  let protocol, str =
+    match cuts ~sep:"://" str with
+    | [ str ] -> (`Socks4a, str)
+    | ("socks4" | "socks4a") :: str -> (`Socks4a, String.concat "://" str)
+    | "socks5" :: str -> (`Socks5, String.concat "://" str)
+    | protocol :: _ -> Fmt.invalid_arg "Invalid protocol: %S" protocol
+    | [] -> assert false
+  in
+  let credential, str =
+    match (protocol, String.split_on_char '@' str) with
+    | _, [] -> assert false
+    | _, [ str ] -> (None, str)
+    | `Socks4a, username :: str -> (Username username, String.concat "@" str)
+    | `Socks5, value :: str ->
+        let[@warning "-8"] (username :: password) =
+          String.split_on_char ':' value
+        in
+        ( Credential (username, String.concat ":" password),
+          String.concat "@" str )
+  in
+  match Ipaddr.with_port_of_string ~default str with
+  | Ok (ipaddr, port) ->
+      Ok (protocol, credential, `Inet (Ipaddr_unix.to_inet_addr ipaddr, port))
+  | Error _ -> (
+      let ( >>= ) = Result.bind in
+      match String.split_on_char ':' str with
+      | [ domain_name ] ->
+          Domain_name.of_string domain_name >>= Domain_name.host
+          >>= fun domain_name ->
+          Ok (protocol, credential, `Domain (domain_name, default))
+      | domain_name :: port -> (
+          let port = String.concat ":" port in
+          try
+            Domain_name.of_string domain_name >>= Domain_name.host
+            >>= fun domain_name ->
+            Ok (protocol, credential, `Domain (domain_name, int_of_string port))
+          with _ -> Error (`Msg "Invalid port"))
+      | _ -> assert false)
+
+let parser str = try parser str with Invalid_argument err -> Error (`Msg err)
+
+let pp_addr ppf = function
+  | `Inet (inet_addr, port) ->
+      Fmt.pf ppf "%s:%d" (Unix.string_of_inet_addr inet_addr) port
+  | `Domain (domain_name, port) ->
+      Fmt.pf ppf "%a:%d" Domain_name.pp domain_name port
+
+let pp ppf (protocol, credential, addr) =
+  match (protocol, credential, addr) with
+  | `Socks5, Credential (username, password), addr ->
+      Fmt.pf ppf "socks5://%s:%s@%a" username password pp_addr addr
+  | `Socks5, None, addr -> Fmt.pf ppf "socks5://%a" pp_addr addr
+  | `Socks4a, None, addr -> Fmt.pf ppf "socks4a://%a" pp_addr addr
+  | `Socks4a, Username username, addr ->
+      Fmt.pf ppf "socks4a://%s@%a" username pp_addr addr
+  | _ -> assert false
+
+let open_write_error = function
+  | Ok _ as value -> value
+  | Error `Closed -> Error `Closed
+  | Error (`Unix _ as err) -> Error err
+
+let socks5_struct_to_sockaddr { Socks.port; address } =
+  let addr =
+    match address with
+    | IPv4_address ipv4 -> Ipaddr.V4 ipv4
+    | IPv6_address ipv6 -> Ipaddr.V6 ipv6
+    | Domain_address _ ->
+        Fmt.invalid_arg "Unexpected domain to cast to a sockaddr"
+  in
+  Unix.ADDR_INET (Ipaddr_unix.to_inet_addr addr, port)
+
+let connect ~happy_eyeballs ~server dst =
+  let open Fiber in
+  let hostname, port = addr_to_string_and_int dst in
+  match server with
+  | `Socks4a, credential, addr ->
+      Bob_happy_eyeballs.connect happy_eyeballs addr
+      >>? fun (sockaddr, socket) ->
+      let username =
+        match credential with
+        | Username username -> username
+        | None -> ""
+        | Credential _ -> assert false
+      in
+      let[@warning "-8"] (Ok req) =
+        Socks.make_socks4_request ~username ~hostname port
+      in
+      fully_write socket
+        (bigstring_of_string req ~off:0 ~len:(String.length req))
+      >>| open_write_error
+      >>? fun () ->
+      let rec go payload =
+        match Socks.parse_socks4_response payload with
+        | Ok "" -> Fiber.return (Ok (sockaddr, socket))
+        | Ok _ ->
+            (* XXX(dinosaure): we know how we should talk to the relay and,
+               actually, the server waits for an identifier from us, it should
+               not send something at this stage. *)
+            Fiber.return (Error (`Msg "Unexpected leftover data"))
+        | Error Socks.Rejected ->
+            Fiber.return (Error (`Msg "Rejected by the SOCKSv4a server"))
+        | Error Socks.Incomplete_response -> (
+            Fiber.read socket >>| reword_error (fun err -> `Unix err)
+            >>? function
+            | `End ->
+                Fiber.return
+                  (Error (`Msg "Incomplete response from the SOCKSv4a server"))
+            | `Data bs -> go (payload ^ bigstring_to_string bs))
+      in
+      go ""
+  | `Socks5, credential, addr ->
+      Bob_happy_eyeballs.connect happy_eyeballs addr
+      >>? fun (_sockaddr, socket) ->
+      let socks5_request =
+        match addr with
+        | `Domain (domain_name, port) ->
+            let domain_name = Domain_name.to_string domain_name in
+            Socks.Connect
+              { Socks.port; address = Socks.Domain_address domain_name }
+        | `Inet (inet_addr, port) -> (
+            match Ipaddr_unix.of_inet_addr inet_addr with
+            | Ipaddr.V4 addr ->
+                Socks.Connect { Socks.port; address = Socks.IPv4_address addr }
+            | Ipaddr.V6 addr ->
+                Socks.Connect { Socks.port; address = Socks.IPv6_address addr })
+      in
+      let auth_req =
+        match credential with
+        | None -> Socks.make_socks5_auth_request ~username_password:false
+        | Credential _ -> Socks.make_socks5_auth_request ~username_password:true
+        | Username _ -> assert false
+      in
+      let[@warning "-8"] (Ok req) = Socks.make_socks5_request socks5_request in
+      fully_write socket
+        (bigstring_of_string auth_req ~off:0 ~len:(String.length auth_req))
+      >>| open_write_error
+      >>? fun () ->
+      let rec go payload =
+        match Socks.parse_socks5_username_password_response payload with
+        | Ok (No_acceptable_methods, _) ->
+            Fiber.return
+              (Error
+                 (`Msg
+                   "No acceptable authentication methods for the SOCKSv5 server"))
+        | Ok (_, leftover) -> Fiber.return (Ok leftover)
+        | Error `Invalid_request ->
+            Fiber.return
+              (Error (`Msg "Invalid response from the SOCKSv5 server"))
+        | Error `Incomplete_request -> (
+            Fiber.read socket >>| reword_error (fun err -> `Unix err)
+            >>? function
+            | `End ->
+                Fiber.return
+                  (Error (`Msg "Incomplete response from the SOCKSv5 server"))
+            | `Data bs -> go (payload ^ bigstring_to_string bs))
+      in
+      go "" >>? fun payload ->
+      fully_write socket
+        (bigstring_of_string req ~off:0 ~len:(String.length req))
+      >>| open_write_error
+      >>? fun () ->
+      let rec go payload =
+        match Socks.parse_socks5_response payload with
+        | Ok (Socks.Succeeded, value, "") ->
+            let sockaddr = socks5_struct_to_sockaddr value in
+            Fiber.return (Ok (sockaddr, socket))
+        | Ok (_, _, _) ->
+            Fiber.return (Error (`Msg "Error from the SOCKSv5 server"))
+        | Error Socks.Invalid_response ->
+            Fiber.return (Error (`Msg "Rejected by the SOCKSv5 server"))
+        | Error Socks.Incomplete_response -> (
+            Fiber.read socket >>| reword_error (fun err -> `Unix err)
+            >>? function
+            | `End ->
+                Fiber.return
+                  (Error (`Msg "Incomplete response from the SOCKSv5 server"))
+            | `Data bs -> go (payload ^ bigstring_to_string bs))
+      in
+      go payload

--- a/lib/bob_socks.ml
+++ b/lib/bob_socks.ml
@@ -1,16 +1,16 @@
 open Stdbob
 open Socks
 
-let fully_write fd bs =
+let fully_write fd str =
   let open Fiber in
   let rec go (off, len) =
     if len > 0 then
-      Fiber.write fd bs ~off ~len >>= function
+      Fiber.write fd str ~off ~len >>= function
       | Ok len' -> go (off + len', len - len')
       | Error err -> Fiber.return (Error err)
     else Fiber.return (Ok ())
   in
-  go (0, Bigarray.Array1.dim bs)
+  go (0, String.length str)
 
 let addr_to_string_and_int = function
   | `Inet (inet_addr, port) -> (Unix.string_of_inet_addr inet_addr, port)
@@ -112,10 +112,7 @@ let connect ~happy_eyeballs ~server dst =
       let[@warning "-8"] (Ok req) =
         Socks.make_socks4_request ~username ~hostname port
       in
-      fully_write socket
-        (bigstring_of_string req ~off:0 ~len:(String.length req))
-      >>| open_write_error
-      >>? fun () ->
+      fully_write socket req >>| open_write_error >>? fun () ->
       let rec go payload =
         match Socks.parse_socks4_response payload with
         | Ok "" -> Fiber.return (Ok (sockaddr, socket))
@@ -132,7 +129,7 @@ let connect ~happy_eyeballs ~server dst =
             | `End ->
                 Fiber.return
                   (Error (`Msg "Incomplete response from the SOCKSv4a server"))
-            | `Data bs -> go (payload ^ bigstring_to_string bs))
+            | `Data str -> go (payload ^ str))
       in
       go ""
   | `Socks5, credential, addr ->
@@ -158,17 +155,15 @@ let connect ~happy_eyeballs ~server dst =
         | Username _ -> assert false
       in
       let[@warning "-8"] (Ok req) = Socks.make_socks5_request socks5_request in
-      fully_write socket
-        (bigstring_of_string auth_req ~off:0 ~len:(String.length auth_req))
-      >>| open_write_error
-      >>? fun () ->
+      fully_write socket auth_req >>| open_write_error >>? fun () ->
       let rec go payload =
         match Socks.parse_socks5_username_password_response payload with
-        | Ok (No_acceptable_methods, _) ->
+        | Ok (false, _) ->
             Fiber.return
               (Error
                  (`Msg
-                   "No acceptable authentication methods for the SOCKSv5 server"))
+                    "No acceptable authentication methods for the SOCKSv5 \
+                     server"))
         | Ok (_, leftover) -> Fiber.return (Ok leftover)
         | Error `Invalid_request ->
             Fiber.return
@@ -179,13 +174,10 @@ let connect ~happy_eyeballs ~server dst =
             | `End ->
                 Fiber.return
                   (Error (`Msg "Incomplete response from the SOCKSv5 server"))
-            | `Data bs -> go (payload ^ bigstring_to_string bs))
+            | `Data str -> go (payload ^ str))
       in
       go "" >>? fun payload ->
-      fully_write socket
-        (bigstring_of_string req ~off:0 ~len:(String.length req))
-      >>| open_write_error
-      >>? fun () ->
+      fully_write socket req >>| open_write_error >>? fun () ->
       let rec go payload =
         match Socks.parse_socks5_response payload with
         | Ok (Socks.Succeeded, value, "") ->
@@ -201,6 +193,6 @@ let connect ~happy_eyeballs ~server dst =
             | `End ->
                 Fiber.return
                   (Error (`Msg "Incomplete response from the SOCKSv5 server"))
-            | `Data bs -> go (payload ^ bigstring_to_string bs))
+            | `Data str -> go (payload ^ str))
       in
       go payload

--- a/lib/bob_socks.ml
+++ b/lib/bob_socks.ml
@@ -204,7 +204,7 @@ let connect_socks5 ~happy_eyeballs ~credential ~addr dst =
     match parse_socks5_response payload with
     | Ok (No_authentication_required, leftover) ->
         Fiber.return (Ok (`No_authentication_required leftover))
-    | Ok (Username_password _, leftover) ->
+    | Ok (Username_password _, leftover) when credential <> None ->
         let username_password_req =
           match credential with
           | None | Username _ -> assert false
@@ -231,18 +231,20 @@ let connect_socks5 ~happy_eyeballs ~credential ~addr dst =
       fully_write socket username_password_req >>| open_write_error
       >>? fun () ->
       let rec go payload =
-        if String.length payload < 2 then
-          Fiber.read socket >>| reword_error (fun err -> `Unix err) >>? function
-          | `End ->
-              Fiber.return
-                (Error (`Msg "Incomplete response from SOCKSv5 server"))
-          | `Data str -> go (payload ^ str)
-        else
-          match String.sub payload 0 2 with
-          | "\x01\x00" ->
-              Fiber.return
-                (Ok (String.sub payload 2 (String.length payload - 2)))
-          | _ -> Fiber.return (Error (`Msg "Invalid username/password"))
+        match Socks.parse_socks5_username_password_response payload with
+        | Ok (true, leftover) -> Fiber.return (Ok leftover)
+        | Ok (false, _leftover) ->
+            Fiber.return (Error (`Msg "Invalid username/password"))
+        | Error `Invalid_request ->
+            Fiber.return
+              (Error (`Msg "Invalid response from the SOCKSv5 server"))
+        | Error `Incomplete_request -> (
+            Fiber.read socket >>| reword_error (fun err -> `Unix err)
+            >>? function
+            | `End ->
+                Fiber.return
+                  (Error (`Msg "Incomplete response from SOCKSv5 server"))
+            | `Data str -> go (payload ^ str))
       in
       go payload >>? fun payload -> finally_connect_socks5 socket payload dst
   | `No_authentication_required payload ->

--- a/lib/bob_socks.ml
+++ b/lib/bob_socks.ml
@@ -111,106 +111,146 @@ let pp_socks5_reply ppf = function
       Fmt.string ppf "Address type not supported"
   | Socks.Unassigned -> Fmt.string ppf "Unassigned"
 
-let connect ~happy_eyeballs ~server dst =
+let connect_socks4 ~happy_eyeballs ~credential ~addr dst =
   let open Fiber in
   let hostname, port = addr_to_string_and_int dst in
+  Bob_happy_eyeballs.connect happy_eyeballs addr >>? fun (sockaddr, socket) ->
+  let username =
+    match credential with
+    | Username username -> username
+    | None -> ""
+    | Credential _ -> assert false
+  in
+  let[@warning "-8"] (Ok req) =
+    Socks.make_socks4_request ~username ~hostname port
+  in
+  fully_write socket req >>| open_write_error >>? fun () ->
+  let rec go payload =
+    match Socks.parse_socks4_response payload with
+    | Ok "" -> Fiber.return (Ok (sockaddr, socket))
+    | Ok _ ->
+        (* XXX(dinosaure): we know how we should talk to the relay and,
+           actually, the server waits for an identifier from us, it should
+           not send something at this stage. *)
+        Fiber.return (Error (`Msg "Unexpected leftover data"))
+    | Error Socks.Rejected ->
+        Fiber.return (Error (`Msg "Rejected by the SOCKSv4a server"))
+    | Error Socks.Incomplete_response -> (
+        Fiber.read socket >>| reword_error (fun err -> `Unix err) >>? function
+        | `End ->
+            Fiber.return
+              (Error (`Msg "Incomplete response from the SOCKSv4a server"))
+        | `Data str -> go (payload ^ str))
+  in
+  go ""
+
+let finally_connect_socks5 socket payload dst =
+  let open Fiber in
+  let socks5_request =
+    match dst with
+    | `Domain (domain_name, port) ->
+        let domain_name = Domain_name.to_string domain_name in
+        Socks.Connect { Socks.port; address = Socks.Domain_address domain_name }
+    | `Inet (inet_addr, port) -> (
+        match Ipaddr_unix.of_inet_addr inet_addr with
+        | Ipaddr.V4 addr ->
+            Socks.Connect { Socks.port; address = Socks.IPv4_address addr }
+        | Ipaddr.V6 addr ->
+            Socks.Connect { Socks.port; address = Socks.IPv6_address addr })
+  in
+  let[@warning "-8"] (Ok req) = Socks.make_socks5_request socks5_request in
+  fully_write socket req >>| open_write_error >>? fun () ->
+  let rec go payload =
+    match Socks.parse_socks5_response payload with
+    | Ok (Socks.Succeeded, value, "") ->
+        let sockaddr = socks5_struct_to_sockaddr value in
+        Fiber.return (Ok (sockaddr, socket))
+    | Ok (reply, _, leftover) ->
+        Fiber.return
+          (Error
+             (msgf "Error from the SOCKSv5 server: %a (%S)" pp_socks5_reply
+                reply leftover))
+    | Error Socks.Invalid_response ->
+        Fiber.return (Error (`Msg "Rejected by the SOCKSv5 server"))
+    | Error Socks.Incomplete_response -> (
+        Fiber.read socket >>| reword_error (fun err -> `Unix err) >>? function
+        | `End ->
+            Fiber.return
+              (Error (`Msg "Incomplete response from the SOCKSv5 server"))
+        | `Data str -> go (payload ^ str))
+  in
+  go payload
+
+let parse_socks5_response payload =
+  match (payload.[0], String.length payload >= 2) with
+  | '\x05', true ->
+      let leftover = String.sub payload 2 (String.length payload - 2) in
+      Ok (Socks.socks5_authentication_method_of_char payload.[1], leftover)
+  | '\x05', false -> Error `Incomplete_response
+  | _ -> Error `Invalid_response
+  | exception _ -> Error `Incomplete_response
+
+let connect_socks5 ~happy_eyeballs ~credential ~addr dst =
+  let open Fiber in
+  Bob_happy_eyeballs.connect happy_eyeballs addr >>? fun (_sockaddr, socket) ->
+  let auth_req =
+    match credential with
+    | None -> Socks.make_socks5_auth_request ~username_password:false
+    | Credential _ -> Socks.make_socks5_auth_request ~username_password:true
+    | Username _ -> assert false
+  in
+  fully_write socket auth_req >>| open_write_error >>? fun () ->
+  let rec go payload =
+    match parse_socks5_response payload with
+    | Ok (No_authentication_required, leftover) ->
+        Fiber.return (Ok (`No_authentication_required leftover))
+    | Ok (Username_password _, leftover) ->
+        let username_password_req =
+          match credential with
+          | None | Username _ -> assert false
+          | Credential (username, password) ->
+              Socks.make_socks5_username_password_request ~username ~password
+              |> Result.get_ok
+        in
+        Fiber.return (Ok (`Authentication (username_password_req, leftover)))
+    | Ok _ ->
+        Fiber.return
+          (error_msgf
+             "No acceptable authentication methods for the SOCKSv5 server")
+    | Error `Invalid_response ->
+        Fiber.return (Error (`Msg "Invalid response from the SOCKSv5 server"))
+    | Error `Incomplete_response -> (
+        Fiber.read socket >>| reword_error (fun err -> `Unix err) >>? function
+        | `End ->
+            Fiber.return
+              (Error (`Msg "Incomplete response from the SOCKSv5 server"))
+        | `Data str -> go (payload ^ str))
+  in
+  go "" >>? function
+  | `Authentication (username_password_req, payload) ->
+      fully_write socket username_password_req >>| open_write_error
+      >>? fun () ->
+      let rec go payload =
+        if String.length payload < 2 then
+          Fiber.read socket >>| reword_error (fun err -> `Unix err) >>? function
+          | `End ->
+              Fiber.return
+                (Error (`Msg "Incomplete response from SOCKSv5 server"))
+          | `Data str -> go (payload ^ str)
+        else
+          match String.sub payload 0 2 with
+          | "\x01\x00" ->
+              Fiber.return
+                (Ok (String.sub payload 2 (String.length payload - 2)))
+          | _ -> Fiber.return (Error (`Msg "Invalid username/password"))
+      in
+      go payload >>? fun payload -> finally_connect_socks5 socket payload dst
+  | `No_authentication_required payload ->
+      finally_connect_socks5 socket payload dst
+
+let connect ~happy_eyeballs ~server dst =
   match server with
   | `Socks4a, credential, addr ->
-      Bob_happy_eyeballs.connect happy_eyeballs addr
-      >>? fun (sockaddr, socket) ->
-      let username =
-        match credential with
-        | Username username -> username
-        | None -> ""
-        | Credential _ -> assert false
-      in
-      let[@warning "-8"] (Ok req) =
-        Socks.make_socks4_request ~username ~hostname port
-      in
-      fully_write socket req >>| open_write_error >>? fun () ->
-      let rec go payload =
-        match Socks.parse_socks4_response payload with
-        | Ok "" -> Fiber.return (Ok (sockaddr, socket))
-        | Ok _ ->
-            (* XXX(dinosaure): we know how we should talk to the relay and,
-               actually, the server waits for an identifier from us, it should
-               not send something at this stage. *)
-            Fiber.return (Error (`Msg "Unexpected leftover data"))
-        | Error Socks.Rejected ->
-            Fiber.return (Error (`Msg "Rejected by the SOCKSv4a server"))
-        | Error Socks.Incomplete_response -> (
-            Fiber.read socket >>| reword_error (fun err -> `Unix err)
-            >>? function
-            | `End ->
-                Fiber.return
-                  (Error (`Msg "Incomplete response from the SOCKSv4a server"))
-            | `Data str -> go (payload ^ str))
-      in
-      go ""
+      connect_socks4 ~happy_eyeballs ~credential ~addr dst
   | `Socks5, credential, addr ->
-      Bob_happy_eyeballs.connect happy_eyeballs addr
-      >>? fun (_sockaddr, socket) ->
-      let socks5_request =
-        match dst with
-        | `Domain (domain_name, port) ->
-            let domain_name = Domain_name.to_string domain_name in
-            Socks.Connect
-              { Socks.port; address = Socks.Domain_address domain_name }
-        | `Inet (inet_addr, port) -> (
-            match Ipaddr_unix.of_inet_addr inet_addr with
-            | Ipaddr.V4 addr ->
-                Socks.Connect { Socks.port; address = Socks.IPv4_address addr }
-            | Ipaddr.V6 addr ->
-                Socks.Connect { Socks.port; address = Socks.IPv6_address addr })
-      in
-      let auth_req =
-        match credential with
-        | None -> Socks.make_socks5_auth_request ~username_password:false
-        | Credential _ -> Socks.make_socks5_auth_request ~username_password:true
-        | Username _ -> assert false
-      in
-      let[@warning "-8"] (Ok req) = Socks.make_socks5_request socks5_request in
-      fully_write socket auth_req >>| open_write_error >>? fun () ->
-      let rec go payload =
-        match Socks.parse_socks5_username_password_response payload with
-        | Ok (false, _) ->
-            Fiber.return
-              (Error
-                 (`Msg
-                    "No acceptable authentication methods for the SOCKSv5 \
-                     server"))
-        | Ok (_, leftover) -> Fiber.return (Ok leftover)
-        | Error `Invalid_request ->
-            Fiber.return
-              (Error (`Msg "Invalid response from the SOCKSv5 server"))
-        | Error `Incomplete_request -> (
-            Fiber.read socket >>| reword_error (fun err -> `Unix err)
-            >>? function
-            | `End ->
-                Fiber.return
-                  (Error (`Msg "Incomplete response from the SOCKSv5 server"))
-            | `Data str -> go (payload ^ str))
-      in
-      go "" >>? fun payload ->
-      fully_write socket req >>| open_write_error >>? fun () ->
-      let rec go payload =
-        match Socks.parse_socks5_response payload with
-        | Ok (Socks.Succeeded, value, "") ->
-            let sockaddr = socks5_struct_to_sockaddr value in
-            Fiber.return (Ok (sockaddr, socket))
-        | Ok (reply, _, leftover) ->
-            Fiber.return
-              (Error
-                 (msgf "Error from the SOCKSv5 server: %a (%S)" pp_socks5_reply
-                    reply leftover))
-        | Error Socks.Invalid_response ->
-            Fiber.return (Error (`Msg "Rejected by the SOCKSv5 server"))
-        | Error Socks.Incomplete_response -> (
-            Fiber.read socket >>| reword_error (fun err -> `Unix err)
-            >>? function
-            | `End ->
-                Fiber.return
-                  (Error (`Msg "Incomplete response from the SOCKSv5 server"))
-            | `Data str -> go (payload ^ str))
-      in
-      go payload
+      connect_socks5 ~happy_eyeballs ~credential ~addr dst

--- a/lib/bob_socks.ml
+++ b/lib/bob_socks.ml
@@ -96,6 +96,21 @@ let socks5_struct_to_sockaddr { Socks.port; address } =
   in
   Unix.ADDR_INET (Ipaddr_unix.to_inet_addr addr, port)
 
+let pp_socks5_reply ppf = function
+  | Socks.Succeeded -> Fmt.string ppf "Succeeeded"
+  | Socks.General_socks_server_failure ->
+      Fmt.string ppf "General socks server failure"
+  | Socks.Connection_not_allowed_by_ruleset ->
+      Fmt.string ppf "Connection not allowed by ruleset"
+  | Socks.Network_unreachable -> Fmt.string ppf "Network unreachable"
+  | Socks.Host_unreachable -> Fmt.string ppf "Host unreachable"
+  | Socks.Connection_refused -> Fmt.string ppf "Connection refused"
+  | Socks.TTL_expired -> Fmt.string ppf "TTL expired"
+  | Socks.Command_not_supported -> Fmt.string ppf "Command not supported"
+  | Socks.Address_type_not_supported ->
+      Fmt.string ppf "Address type not supported"
+  | Socks.Unassigned -> Fmt.string ppf "Unassigned"
+
 let connect ~happy_eyeballs ~server dst =
   let open Fiber in
   let hostname, port = addr_to_string_and_int dst in
@@ -136,7 +151,7 @@ let connect ~happy_eyeballs ~server dst =
       Bob_happy_eyeballs.connect happy_eyeballs addr
       >>? fun (_sockaddr, socket) ->
       let socks5_request =
-        match addr with
+        match dst with
         | `Domain (domain_name, port) ->
             let domain_name = Domain_name.to_string domain_name in
             Socks.Connect
@@ -183,8 +198,11 @@ let connect ~happy_eyeballs ~server dst =
         | Ok (Socks.Succeeded, value, "") ->
             let sockaddr = socks5_struct_to_sockaddr value in
             Fiber.return (Ok (sockaddr, socket))
-        | Ok (_, _, _) ->
-            Fiber.return (Error (`Msg "Error from the SOCKSv5 server"))
+        | Ok (reply, _, leftover) ->
+            Fiber.return
+              (Error
+                 (msgf "Error from the SOCKSv5 server: %a (%S)" pp_socks5_reply
+                    reply leftover))
         | Error Socks.Invalid_response ->
             Fiber.return (Error (`Msg "Rejected by the SOCKSv5 server"))
         | Error Socks.Incomplete_response -> (

--- a/lib/bob_socks.mli
+++ b/lib/bob_socks.mli
@@ -1,0 +1,16 @@
+type addr =
+  [ `Inet of Unix.inet_addr * int | `Domain of [ `host ] Domain_name.t * int ]
+
+type server
+
+val parser : string -> (server, [> `Msg of string ]) result
+val pp : server Fmt.t
+
+val connect :
+  happy_eyeballs:Bob_happy_eyeballs.t ->
+  server:server ->
+  addr ->
+  ( Unix.sockaddr * Unix.file_descr,
+    [> `Closed | `Msg of string | `Unix of Unix.error ] )
+  result
+  Fiber.t

--- a/lib/bob_unix.ml
+++ b/lib/bob_unix.ml
@@ -83,7 +83,7 @@ module Make (IO : IO) = struct
 
   type outcome = [ `Write of string | `Error of error | `Done | `Continue ]
 
-  let run ~choose ~agreement ~receive ~send socket t =
+  let run ~choose ~agreement ?identity ~receive ~send socket t =
     let handshake_is_done : [ `Done ] Fiber.Ivar.t = Fiber.Ivar.create () in
     let errored : [ `Error of error ] Fiber.Ivar.t = Fiber.Ivar.create () in
     let rec read () =
@@ -100,6 +100,11 @@ module Make (IO : IO) = struct
           Log.debug (fun m -> m "recv <- %a" pp_data data);
           match receive t data with
           | `Continue | `Read -> Fiber.pause () >>= read
+          | `Identity str ->
+              (match identity with
+              | Some fn -> fn str
+              | None -> Fiber.return ())
+              >>= read
           | `Agreement identity ->
               choose identity >>= fun v ->
               agreement t v;
@@ -167,22 +172,30 @@ module Make (IO : IO) = struct
 
   let open_error = function Ok _ as v -> v | Error #error as v -> v
 
-  let server socket ?reproduce ~g secret =
+  let server socket ?reproduce ~g ?identity secret =
     let t = Bob.Server.hello ?reproduce ~g secret in
     let choose _ = assert false in
     let agreement _ = assert false in
-    run ~choose ~agreement ~receive:Bob.Server.receive ~send:Bob.Server.send
-      socket t
+    run ~choose ~agreement ~receive:Bob.Server.receive ?identity
+      ~send:Bob.Server.send socket t
     >>| open_error
 
-  let client socket ?reproduce ~choose ~g password =
-    let identity = Unix.gethostname () in
-    let t = Bob.Client.make ?reproduce ~g ~identity password in
-    run ~choose ~agreement:Bob.Client.agreement ~receive:Bob.Client.receive
-      ~send:Bob.Client.send socket t
+  let client socket ?reproduce ~choose ~g ?identity password =
+    let hostname = Unix.gethostname () in
+    (* TODO(dinosaure): delete [identity]. *)
+    let t = Bob.Client.make ?reproduce ~g ~identity:hostname password in
+    run ~choose ~agreement:Bob.Client.agreement ?identity
+      ~receive:Bob.Client.receive ~send:Bob.Client.send socket t
     >>| open_error
 
-  let relay ?(timeout = 3600.) socket rooms ~stop =
+  let generate_identity ~g =
+    let res = Bytes.make 16 '\000' in
+    for i = 0 to 15 do
+      Bytes.set res i (Char.unsafe_chr (Random.State.int g 256))
+    done;
+    Base64.encode_exn (Bytes.unsafe_to_string res)
+
+  let relay ~g ?(timeout = 3600.) socket rooms ~stop =
     let t = Bob.Relay.make () in
     let fds = Hashtbl.create 0x100 in
     let rec write () =
@@ -265,8 +278,14 @@ module Make (IO : IO) = struct
             fds;
           Fiber.pause () >>= read
     in
-    let handler fd sockaddr =
-      let identity = Fmt.str "%a" pp_sockaddr sockaddr in
+    let handler fd _sockaddr =
+      let identity =
+        let rec go () =
+          let str = generate_identity ~g in
+          if Hashtbl.mem fds str then go () else str
+        in
+        go ()
+      in
       Log.debug (fun m -> m "Add %s as an active connection." identity);
       IO.of_file_descr fd >>= function
       | Error err ->
@@ -343,9 +362,14 @@ let rec loop ~timeout t ready queue state fd k =
   >>= function
   | `Closed | `Bounded _ -> Fiber.return ()
   | `Continue k -> loop t ~timeout ready queue state fd k
-  | `Error _ | `Invalid_peer ->
+  | (`Error _ | `Invalid_peer) as err ->
+      let err =
+        match err with
+        | `Error (`Rd err) -> Fmt.str "read(): %s" (Unix.error_message err)
+        | `Invalid_peer -> "Invalid peer"
+      in
       Log.err (fun m ->
-          m "Got an error from %a." pp_sockaddr (Unix.getpeername fd));
+          m "Got an error from %a: %s" pp_sockaddr (Unix.getpeername fd) err);
       if Fiber.Ivar.is_empty state then (
         Fiber.Ivar.fill state `Closed;
         full_write fd _02 ~off:0 ~len:2 >>= fun _ -> Fiber.close fd)

--- a/lib/bob_unix.mli
+++ b/lib/bob_unix.mli
@@ -47,6 +47,7 @@ module Make (IO : IO) : sig
     IO.fd ->
     ?reproduce:bool ->
     g:Random.State.t ->
+    ?identity:(string -> unit Fiber.t) ->
     Spoke.secret ->
     ( string * (Spoke.cipher * Spoke.cipher) * Spoke.shared_keys,
       [> error ] )
@@ -61,6 +62,7 @@ module Make (IO : IO) : sig
     ?reproduce:bool ->
     choose:(string -> [ `Accept | `Refuse ] Fiber.t) ->
     g:Random.State.t ->
+    ?identity:(string -> unit Fiber.t) ->
     string ->
     ( string * (Spoke.cipher * Spoke.cipher) * Spoke.shared_keys,
       [> error ] )
@@ -72,12 +74,13 @@ module Make (IO : IO) : sig
       accept or refuse the peer found. *)
 
   val relay :
+    g:Random.State.t ->
     ?timeout:float ->
     Unix.file_descr ->
     Bob.Secured.t ->
     stop:unit Fiber.Ivar.t ->
     unit Fiber.t
-  (** [relay ?timeout socket room ~stop] launch a relay which can accept
+  (** [relay ~g ?timeout socket room ~stop] launch a relay which can accept
       connections from [socket]. The user can specify a [timeout] value (how
       long the relay can keep an active connection with a peer). If [stop] is
       filled, the relay terminates. The given [room] is filled by peers which

--- a/lib/dune
+++ b/lib/dune
@@ -35,7 +35,7 @@
  (name password)
  (public_name bob.password)
  (modules password)
- (libraries bob.dict))
+ (libraries fmt base64 bob.dict))
 
 (library
  (name fiber)
@@ -97,7 +97,7 @@
  (name bob_unix)
  (public_name bob.unix)
  (modules bob_unix)
- (libraries psq hxd.core hxd.string bob bob.fiber))
+ (libraries base64 psq hxd.core hxd.string bob bob.fiber))
 
 (library
  (name bob_dns)
@@ -127,3 +127,9 @@
  (public_name bob.tls)
  (modules bob_tls)
  (libraries tls cstruct bob.fiber))
+
+(library
+ (name bob_socks)
+ (public_name bob.socks)
+ (modules bob_socks)
+ (libraries socks bob.happy-eyeballs))

--- a/lib/handshake.ml
+++ b/lib/handshake.ml
@@ -77,6 +77,7 @@ type error =
   | `Invalid_header
   | `Invalid_new_server
   | `Invalid_uid
+  | `Unexpected_packet
   | Spoke.error ]
 
 let pp_error ppf = function
@@ -86,6 +87,7 @@ let pp_error ppf = function
   | `Invalid_header -> Fmt.pf ppf "Invalid header"
   | `Invalid_new_server -> Fmt.string ppf "Invalid new server"
   | `Invalid_uid -> Fmt.string ppf "Invalid UID"
+  | `Unexpected_packet -> Fmt.string ppf "Unexpected packet"
   | #Spoke.error as err -> Spoke.pp_error ppf err
 
 type 'a t =

--- a/lib/handshake.mli
+++ b/lib/handshake.mli
@@ -11,6 +11,7 @@ type error =
   | `Invalid_header
   | `Invalid_new_server
   | `Invalid_uid
+  | `Unexpected_packet
   | Spoke.error ]
 
 val pp_error : error Fmt.t

--- a/lib/password.ml
+++ b/lib/password.ml
@@ -86,3 +86,14 @@ let generate ?g (starters, wordparts) length =
     | None -> ()
   done;
   Buffer.contents buf
+
+let identity_of_seed ~seed t =
+  match Base64.decode seed with
+  | Ok seed ->
+      let arr =
+        Array.init (String.length seed) (fun idx -> Char.code seed.[idx])
+      in
+      let g = Random.State.make arr in
+      let ps = Array.init 2 (fun _ -> generate ~g t (Random.State.int g 5)) in
+      Ok (Fmt.str "%s-%s" ps.(0) ps.(1))
+  | Error _ as err -> err

--- a/lib/password.mli
+++ b/lib/password.mli
@@ -13,3 +13,5 @@ val generate : ?g:Random.State.t -> t -> int -> string
 (** [generate ?g t len] generates a {b weak} password with [len] {i syllable}
     from a {{!type:t} dictionary} and a possible {!Random.State.t} (otherwise,
     we generate one with {!val:Random.State.make_self_init}). *)
+
+val identity_of_seed : seed:string -> t -> (string, [> `Msg of string ]) result

--- a/lib/state.ml
+++ b/lib/state.ml
@@ -353,6 +353,7 @@ module Server = struct
       (a, server) src ->
       (a, server) packet ->
       [> `Continue
+      | `Identity of string
       | `Done of string * (Spoke.cipher * Spoke.cipher) * Spoke.shared_keys
       | `Close ] =
    fun t source packet ->
@@ -370,7 +371,7 @@ module Server = struct
         `Continue
     | Relay, Server_identity identity ->
         t.identity <- identity;
-        `Continue
+        `Identity identity
     | Peer (Client, uid), X_and_client_identity { _X; identity } -> (
         let identities =
           match t.reproduce with
@@ -477,6 +478,7 @@ module Client = struct
       (a, client) packet ->
       [> `Continue
       | `Agreement of string
+      | `Identity of string
       | `Done of string * (Spoke.cipher * Spoke.cipher) * Spoke.shared_keys
       | `Close ] =
    fun t source packet ->
@@ -494,7 +496,7 @@ module Client = struct
         `Continue
     | Relay, Client_identity identity ->
         t.identity <- identity;
-        `Continue
+        `Identity identity
     | Relay, New_server { uid; public; identity } -> (
         Log.debug (fun m ->
             m "A new server (%04x, %s) is available." uid identity);

--- a/lib/state.mli
+++ b/lib/state.mli
@@ -56,6 +56,7 @@ module Server : sig
     ('a, server) src ->
     ('a, server) packet ->
     [> `Continue
+    | `Identity of string
     | `Done of string * (Spoke.cipher * Spoke.cipher) * Spoke.shared_keys
     | `Close ]
 
@@ -77,6 +78,7 @@ module Client : sig
     ('a, client) packet ->
     [> `Continue
     | `Agreement of string
+    | `Identity of string
     | `Done of string * (Spoke.cipher * Spoke.cipher) * Spoke.shared_keys
     | `Close ]
 

--- a/lib/stdbob.ml
+++ b/lib/stdbob.ml
@@ -7,6 +7,7 @@ let msgf fmt = Fmt.kstr (fun msg -> `Msg msg) fmt
 let io_buffer_size = 65536 (* 0x10000 & = De.io_buffer_size *)
 let reword_error f = function Ok x -> Ok x | Error err -> Error (f err)
 let never _ = assert false
+let error_msgf fmt = Fmt.kstr (fun msg -> Error (`Msg msg)) fmt
 
 external reraise : exn -> 'a = "%reraise"
 

--- a/lib/stdbob.ml
+++ b/lib/stdbob.ml
@@ -112,3 +112,26 @@ let bytes_to_size ?(decimals = 2) ppf = function
       let i = Float.floor (Float.log n /. Float.log 1024.) in
       let r = n /. Float.pow 1024. i in
       Fmt.pf ppf "%.*f %s" decimals r sizes.(int_of_float i)
+
+let add str ~start ~stop acc =
+  if start = stop then "" :: acc else String.sub str start (stop - start) :: acc
+
+let cuts ~sep str =
+  let sep_len = String.length sep in
+  if sep_len = 0 then invalid_arg "Stdbob.cuts";
+  let str_len = String.length str in
+  let max_sep_idx = sep_len - 1 in
+  let max_str_idx = str_len - sep_len in
+  let rec check_sep start i k acc =
+    if k > max_sep_idx then
+      let new_start = i + sep_len in
+      scan new_start new_start (add str ~start ~stop:i acc)
+    else if str.[i + k] = sep.[k] then check_sep start i (k + 1) acc
+    else scan start (i + 1) acc
+  and scan start i acc =
+    if i > max_str_idx then
+      if start = 0 then [ str ] else List.rev (add str ~start ~stop:str_len acc)
+    else if str.[i] = sep.[0] then check_sep start i 1 acc
+    else scan start (i + 1) acc
+  in
+  scan 0 0 []

--- a/lib/stdbob.mli
+++ b/lib/stdbob.mli
@@ -6,6 +6,10 @@ val ( <.> ) : ('a -> 'b) -> ('c -> 'a) -> 'c -> 'b
 val msgf : ('a, Format.formatter, unit, [> `Msg of string ]) format4 -> 'a
 val reword_error : ('e0 -> 'e1) -> ('a, 'e0) result -> ('a, 'e1) result
 val never : 'a -> 'b
+
+val error_msgf :
+  ('a, Format.formatter, unit, ('b, [> `Msg of string ]) result) format4 -> 'a
+
 val io_buffer_size : int
 val reraise : exn -> 'a
 val line_of_queue : (char, Bigarray.int8_unsigned_elt) Ke.Rke.t -> string option

--- a/lib/stdbob.mli
+++ b/lib/stdbob.mli
@@ -38,3 +38,4 @@ module LList : sig
 end
 
 val bytes_to_size : ?decimals:int -> int Fmt.t
+val cuts : sep:string -> string -> string list

--- a/mirage/config.ml
+++ b/mirage/config.ml
@@ -12,6 +12,7 @@ let bob =
         package "spoke" ~sublibs:[ "core" ]
           ~pin:"git+https://github.com/dinosaure/spoke.git";
         package "psq";
+        package "base64";
       ]
     (time @-> stackv4v6 @-> job)
 

--- a/mirage/unikernel.ml
+++ b/mirage/unikernel.ml
@@ -133,7 +133,15 @@ module Make (Time : Mirage_time.S) (Stack : Tcpip.Stack.V4V6) = struct
     [ `Write of string * string | `Close of string | `Continue ]
 
   module Make (Flow : Mirage_flow.S) = struct
-    let relay ?(timeout = 3600_000_000_000L) ~port ~handshake ?stop tcp rooms =
+    let relay ~g ?(timeout = 3600_000_000_000L) ~port ~handshake ?stop tcp rooms
+        =
+      let generate_identity ~g =
+        let res = Bytes.make 16 '\000' in
+        for i = 0 to 15 do
+          Bytes.set res i (Char.unsafe_chr (Random.State.int g 256))
+        done;
+        Base64.encode_exn (Bytes.unsafe_to_string res)
+      in
       let wr_condition = Lwt_condition.create () in
       let rd_condition = Lwt_condition.create () in
       let t = Bob.Relay.make () in
@@ -235,10 +243,18 @@ module Make (Time : Mirage_time.S) (Stack : Tcpip.Stack.V4V6) = struct
             read ()
       in
       let handler (fd, (ipaddr, port)) =
-        let identity = Fmt.str "%a:%d" Ipaddr.pp ipaddr port in
+        let identity =
+          let rec go () =
+            let str = generate_identity ~g in
+            if Hashtbl.mem fds str then go () else str
+          in
+          go ()
+        in
         Hashtbl.add fds identity (fd, Lwt.return `Continue);
         Bob.Relay.new_peer t ~identity;
-        Logs.debug (fun m -> m "Open a new connection with %S" identity);
+        Logs.debug (fun m ->
+            m "Open a new connection with %S (%a:%d)" identity Ipaddr.pp ipaddr
+              port);
         Lwt_condition.signal rd_condition ();
         Lwt_condition.signal wr_condition ();
         Lwt.async (fun () ->
@@ -468,10 +484,13 @@ module Make (Time : Mirage_time.S) (Stack : Tcpip.Stack.V4V6) = struct
 
   let start _time stack { K.port; K.secure_port } =
     let rooms = Bob.Secured.make () in
+    let g = Random.State.make_self_init () in
     let handshake socket = Lwt.return (Ok (socket, Stack.TCP.dst socket)) in
     Lwt.join
       [
-        Bob_clear.relay ~port ~handshake (Stack.tcp stack) rooms;
-        Secured.secure_room ~port:secure_port (Stack.tcp stack) rooms;
+        Bob_clear.relay ~g ~port:(Key_gen.port ()) ~handshake (Stack.tcp stack)
+          rooms;
+        Secured.secure_room ~port:(Key_gen.secure_port ()) (Stack.tcp stack)
+          rooms;
       ]
 end


### PR DESCRIPTION
This PR breaks our protocol where the identity of peers matters now. The identity is not the IP address of the peer but a seed generated by the relay. The relay send this seed to peers and we use them to initiate then a secure room which does not rely on the public IP address (which can change now via the Tor protocol).

This PR also improve a bit how we handle Bob's packets and events. Now, the sender has an identity generated by the relay and the receiver receive a request from a certain identity. If this identity matches with the sender's identity (which show up into the CLI), the receiver can safely accepts the incoming PACK file now.

We need to test it in real world, this PR is created as a draft.