### PR TITLE
Help opam detect pin src type

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ How to receive a file (with the same password):<br />
 
 You can compile & install bob with [opam][opam]:
 ```sh
-$ opam pin add -y https://github.com/dinosaure/bob
+$ opam pin add -y https://github.com/dinosaure/bob.git
 ```
 
 Bob has 3 sub-programs, the receiver, the sender and the relay. We will


### PR DESCRIPTION
Without this opam 2.2.0 fails with:

```
[ERROR] Could not retrieve Could not extract archive:
        Unknown archive type: /tmp/opam-75458-5f046f/bob
```
